### PR TITLE
feat: support name prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ export default {
 - `alias`: Add single or multiple aliases to page
 - `meta`: Add Meta information to the page, meta can be used by middlewares
 - `props`: Pass predefined props to page
+- `name`: Define custom name for route.
     
 ## Syntax Highlighting
 ### Visual Studio Code

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -181,6 +181,7 @@ export default {
 
 <router lang="yaml">
   path: /
+  name: docs-main
   alias:
     - /doc
     -

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,11 +7,13 @@ export const VALID_EXTRAS = [
   'path',
   'alias',
   'meta',
-  'props'
+  'props',
+  'name'
 ]
 
 export const NUXT_VALID_EXTRAS = [
   'path',
   'meta',
-  'props'
+  'props',
+  'name'
 ]

--- a/lib/extras.js
+++ b/lib/extras.js
@@ -47,7 +47,7 @@ export async function extendRoutes(routes, options) {
 function mapSimpleAliases(route, aliases) {
   return aliases.map((alias, index) => Object.assign({}, route, {
     path: alias,
-    name: `${route.name}-p${alias}`
+    name: `${route.name}${alias}`
   }))
 }
 
@@ -55,7 +55,7 @@ function mapObjectAliases(route, aliases) {
   return aliases.map((alias, index) => Object.assign({}, route, {
     ...pick(alias, NUXT_VALID_EXTRAS),
     path: alias.path,
-    name: `${route.name}-p${alias.path}`
+    name: `${route.name}${alias.path}`
   }))
 }
 


### PR DESCRIPTION
- Allow `name` to be a valid prop
- Add `name` to the example/fixture
- Make aliased path names simpler (Like `docs-main/doc/meta`)