### PR TITLE
fix: multiple loaders configured e.g. vuetify-loader

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,0 +1,3 @@
+module.exports =  function () {
+  return ''
+}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,3 +1,3 @@
-module.exports =  function () {
+module.exports = function () {
   return ''
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,11 +7,12 @@ import { DEFAULT_OPTIONS } from './constants'
 export default async function module (moduleOptions) {
   const options = { ...DEFAULT_OPTIONS, ...moduleOptions, ...this.options.routerExtras }
 
-  this.extendBuild(config =>
+  this.extendBuild((config) => {
     config.module.rules.push({
       resourceQuery: /blockType=router/,
       loader: require.resolve('./loader')
     })
+  }
   )
 
   await init.call(this, options)

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,6 +7,13 @@ import { DEFAULT_OPTIONS } from './constants'
 export default async function module (moduleOptions) {
   const options = { ...DEFAULT_OPTIONS, ...moduleOptions, ...this.options.routerExtras }
 
+  this.extendBuild(config => {
+    config.module.rules.push({
+      resourceQuery: /blockType=router/,
+      loader: require.resolve('./loader')
+    })
+  })
+
   await init.call(this, options)
 
   await setupHooks.call(this, options)

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,12 +7,12 @@ import { DEFAULT_OPTIONS } from './constants'
 export default async function module (moduleOptions) {
   const options = { ...DEFAULT_OPTIONS, ...moduleOptions, ...this.options.routerExtras }
 
-  this.extendBuild(config => {
+  this.extendBuild(config =>
     config.module.rules.push({
       resourceQuery: /blockType=router/,
       loader: require.resolve('./loader')
     })
-  })
+  )
 
   await init.call(this, options)
 


### PR DESCRIPTION
fixes #15 https://github.com/vuetifyjs/vuetify-loader/issues/47

When there more than only vue-loader ( or vue-loader and cache-loader ) configured, vue-loader wont ignore custom block and loader that process it must exist. 

https://github.com/vuejs/vue-loader/blob/c359a38db0fbb4135fc97114baec3cd557d4123a/lib/loaders/pitcher.js#L30