### PR TITLE
feat: added support for named views (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,46 @@ Aliases can have their own props
 
 </details>
 
+
+### Define named views for the page
+
+<details open>
+  <summary>JavaScript</summary>
+
+```xml
+<router>
+{
+  namedViews: {
+    currentView: 'main',
+    views: {
+      side: '~/components/side.vue'
+    },
+    chunkNames: {
+      side: 'components/side'
+    }
+  }
+}
+</router>
+```
+
+</details>
+
+<details>
+  <summary>Yaml</summary>
+
+```xml
+<router>
+  namedViews:
+    currentView: "main"
+    views:
+      side: "~/components/side.vue"
+    chunkNames:
+      side: "~/components/side.vue"
+</router>
+```
+
+</details>
+
 ## Valid Extras
 |     Extras       |  Support  | Description |
 |     -----        |  -------  | ----------- |
@@ -206,6 +246,18 @@ Aliases can have their own props
 | `beforeEnter`    |    JS     | Define `beforeEnter` guard for this route, see: [Global Before Guards](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards) |
 | `caseSensitive`  | JS & YAML | Use case sensitive route match (default: false) |
 | `redirect`       | JS & YAML | Redirect current page to new location|
+| `namedViews`     | JS & YAML | Add named view to the path, see [Named Views Support](#named-views-support) |
+
+## Named views support
+
+There is support for [named views in nuxt](https://nuxtjs.org/guide/routing#named-views), but it requires the user to write a lot of boilerplate code in the config. The `namedViews` property in the `<router>` block allows for a more streamlined configuration 
+
+Named views key is a bit different from all other settings. It expects an object with following properties:
+- `currentView`: actual view name for the current component. Defaults to `"default"`, to be rendered in plain `<nuxt-child />`
+- `views`: object, where keys are view names and values are component paths. It supports all expected path resolution (`~/` and others)
+- `chunkNames`: object, where keys are view names and values are webpack chunks for them. Object structure is expected to be equal to `views` - all the same keys must be present.
+
+For usage example see `example/pages/namedParent.vue` and `example/pages/namedParent/namedChild.vue`. 
 
 ## Syntax Highlighting
 

--- a/example/components/otherside.vue
+++ b/example/components/otherside.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>Other side component</div>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/example/components/side.vue
+++ b/example/components/side.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>Side component</div>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/example/pages/namedParent.vue
+++ b/example/pages/namedParent.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>Named parent</h1>
+    <nuxt-child name="main" />
+    <nuxt-child name="side" />
+    <nuxt-child name="otherside" />
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/example/pages/namedParent/namedChild.vue
+++ b/example/pages/namedParent/namedChild.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>Named child</div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+<router lang="js">
+{
+  namedViews: {
+    currentView: 'main',
+    views: {
+      side: '~/components/side.vue',
+      otherside: '../../components/otherside.vue'
+    },
+    chunkNames: {
+      side: 'components/side',
+      otherside: 'components/otherside'
+    }
+  }
+}
+</router>

--- a/lib/extras.js
+++ b/lib/extras.js
@@ -1,4 +1,5 @@
 const { readFileSync } = require('fs')
+const { dirname } = require('path')
 const matter = require('gray-matter')
 
 const VALID_EXTRAS = [
@@ -9,6 +10,7 @@ const VALID_EXTRAS = [
   'name',
   'redirect',
   'beforeEnter',
+  'namedViews',
   // 2.6.0+
   'caseSensitive',
   'pathToRegexpOptions'
@@ -26,6 +28,24 @@ const NUXT_VALID_EXTRAS = [
   'pathToRegexpOptions'
 ]
 
+const NAMED_VIEWS_VALID_KEYS = [
+  'currentView',
+  'views',
+  'chunkNames'
+]
+
+class NamedViewsValidationError extends Error {
+  constructor (componentPath) {
+    super(`
+Error in router block in file ${componentPath}:
+  property "namedViews" must be an object with following keys:
+    - "currentView": string, optional, default: 'default'
+    - "views": object with string keys and component path values
+    - "chunkNames": object with _exactly_ the same keys as "view" and string values, must be present with "views"
+            `.trim())
+  }
+}
+
 /**
  * cache extracted extras
  */
@@ -33,7 +53,28 @@ const parsedRoutes = {}
 
 let localRoutes = []
 
-function extendRoutes (routes, options) {
+/**
+ * Resolve absolute path for the component since nuxt resolution function
+ * doesn't seem to do that
+ *
+ * @param {string} target component path (may be relative)
+ * @param {string} current calling component path (route.component)
+ * @param {string} srcDir src dir, aliased as `~/` or `@/`
+ * @param {string} rootDir root dir, aliased as `~~/` or `@@/`
+ * @param {(...args: string[]) => string} resolver nuxt resolution function, to join path parts
+ * @returns {string} an absolute path without aliases
+ */
+function resolveChild (target, current, srcDir, rootDir, resolver) {
+  if (target.startsWith('@/') || target.startsWith('~/')) {
+    return resolver(srcDir, target.substring(2))
+  } else if (target.startsWith('@@/') || target.startsWith('~~/')) {
+    return resolver(rootDir, target.substring(3))
+  } else {
+    return resolver(dirname(current), target)
+  }
+}
+
+function extendRoutes (routes, options, resolve, { srcDir, rootDir }) {
   localRoutes = localRoutes.concat(routes)
 
   let additionalRoutes = []
@@ -42,6 +83,38 @@ function extendRoutes (routes, options) {
     const extras = extractExtrasFromRoute(route)
 
     Object.assign(route, pick(extras, NUXT_VALID_EXTRAS))
+
+    // handle named views
+    const { namedViews = undefined } = extras
+
+    if (namedViews) {
+      const preparedComponents = {}
+
+      for (const [key, component] of Object.entries(namedViews.views)) {
+        preparedComponents[key] = resolveChild(component, route.component, srcDir, rootDir, resolve)
+      }
+
+      // We need to set default even if current view name is specified
+      // because nuxt expects the default component to be present
+      // and throws runtime webpack error otherwise
+      preparedComponents[namedViews.currentView] = route.component
+      preparedComponents.default = route.component
+
+      const chunkNames = namedViews.chunkNames
+
+      if (namedViews.currentView !== 'default') {
+        chunkNames.default = route.chunkName
+        chunkNames[namedViews.currentView] = route.chunkName
+      }
+
+      Object.assign(route, {
+        components: preparedComponents,
+        chunkNames: namedViews.chunkNames
+      })
+
+      delete route.component
+      delete route.chunkName
+    }
 
     const { alias = [] } = extras
     const simpleAlias = alias.filter(alias => typeof alias === 'string')
@@ -63,7 +136,7 @@ function extendRoutes (routes, options) {
 
     // process child routes
     if (Array.isArray(route.children)) {
-      extendRoutes(route.children, options)
+      extendRoutes(route.children, options, resolve, { srcDir, rootDir })
     }
   }
 
@@ -118,7 +191,7 @@ function extractExtrasFromRoute (route, useCache = true) {
       '---'
     ].join('\n'))
 
-    extras = validateExtras(parsed.data)
+    extras = validateExtras(parsed.data, route.component)
     // Keep raw value to detect changes
     extras._raw = routerBlock.content
     // Wheter route need to update or not
@@ -157,7 +230,7 @@ function extractRouterBlockFromFile (path) {
   return null
 }
 
-function validateExtras (extras) {
+function validateExtras (extras, componentPath) {
   // Validate path
   if (extras.path && typeof extras.path !== 'string') {
     extras.path = String(extras.path)
@@ -168,7 +241,56 @@ function validateExtras (extras) {
     extras.alias = [String(extras.alias)]
   }
 
+  // Validate named views
+  if (extras.namedViews) {
+    extras.namedViews = validateNamedViews(extras.namedViews, componentPath)
+  }
+
   return pick(extras, VALID_EXTRAS)
+}
+
+function validateNamedViews (namedViews, componentPath) {
+  if (typeof namedViews !== 'object') {
+    throw new NamedViewsValidationError(componentPath)
+  }
+
+  const validObject = pick(namedViews, NAMED_VIEWS_VALID_KEYS)
+
+  if (validObject.currentView && typeof validObject.currentView !== 'string') {
+    throw new NamedViewsValidationError(componentPath)
+  } else if (!validObject.currentView) {
+    validObject.currentView = 'default'
+  }
+
+  if (validObject.views && typeof validObject.views !== 'object') {
+    throw new NamedViewsValidationError(componentPath)
+  }
+
+  if (validObject.views) {
+    for (const [key, value] of Object.entries(validObject.views)) {
+      if (typeof key !== 'string' || typeof value !== 'string') {
+        throw new NamedViewsValidationError(componentPath)
+      }
+    }
+  }
+
+  if (validObject.views && !validObject.chunkNames) {
+    throw new NamedViewsValidationError(componentPath)
+  }
+
+  if (validObject.chunkNames) {
+    const viewsKeys = Object.keys(validObject.views)
+
+    for (const key of viewsKeys) {
+      if (!validObject.chunkNames.hasOwnProperty(key)) {
+        throw new NamedViewsValidationError(componentPath)
+      } else if (typeof validObject.chunkNames[key] !== 'string') {
+        validObject.chunkNames[key] = String(validObject.chunkNames[key])
+      }
+    }
+  }
+
+  return validObject
 }
 
 function extractLanguage (content, attrs) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -13,6 +13,9 @@ module.exports = function (moduleOptions) {
 
   let filesWatcher
 
+  const srcDir = this.nuxt.options.srcDir
+  const rootDir = this.nuxt.options.rootDir
+
   this.extendBuild((config) => {
     config.module.rules.push({
       resourceQuery: /blockType=router/,
@@ -20,7 +23,9 @@ module.exports = function (moduleOptions) {
     })
   })
 
-  this.nuxt.hook('build:extendRoutes', routes => extendRoutes(routes, options))
+  this.nuxt.hook('build:extendRoutes', (routes, resolve) =>
+    extendRoutes(routes, options, resolve, { srcDir, rootDir })
+  )
 
   this.nuxt.hook('build:done', (builder) => {
     if (this.options.dev) {

--- a/test/dev.test.js
+++ b/test/dev.test.js
@@ -60,4 +60,14 @@ describe('dev', () => {
       expect(html).not.toContain('yarn add @nuxtjs/router-extras')
     })
   })
+
+  describe('named views', () => {
+    test('render child with named component', async () => {
+      const html = await get('/namedParent/namedChild')
+      expect(html).toContain('Named parent')
+      expect(html).toContain('Named child')
+      expect(html).toContain('Side component')
+      expect(html).toContain('Other side component')
+    })
+  })
 })

--- a/test/prod.test.js
+++ b/test/prod.test.js
@@ -58,4 +58,14 @@ describe('prod', () => {
       expect(html).not.toContain('yarn add @nuxtjs/router-extras')
     })
   })
+
+  describe('named views', () => {
+    test('render child with named component', async () => {
+      const html = await get('/namedParent/namedChild')
+      expect(html).toContain('Named parent')
+      expect(html).toContain('Named child')
+      expect(html).toContain('Side component')
+      expect(html).toContain('Other side component')
+    })
+  })
 })


### PR DESCRIPTION
Closes #84 

This PR adds support for named views. This is to simplify the boilerplate currently present in [nuxt named views](https://nuxtjs.org/guide/routing#named-views).

API is simple: an object with three properties:
- `currentView`: actual view name for the current component. Defaults to `"default"`, to be rendered in plain `<nuxt-child />`
- `views`: object, where keys are view names and values are component paths. It supports all expected path resolution (`~/` and others)
- `chunkNames`: object, where keys are view names and values are webpack chunks for them. Object structure is expected to be equal to `views` - all the same keys must be present.